### PR TITLE
Update Form1.vb

### DIFF
--- a/TcJoy .NET Project/TcJoy/Form1.vb
+++ b/TcJoy .NET Project/TcJoy/Form1.vb
@@ -489,8 +489,8 @@ Public Class Form1
                         End If
 
                     Case TextBox_TcJoyPath.Text + ".iRightStick_X_Axis"
-                        If Math.Abs(MyController.LeftThumbStick.X) > CInt(TextBox_AnalogDeadzone.Text) Then
-                            Tag.Value = MyController.LeftThumbStick.X
+                        If Math.Abs(MyController.RightThumbStick.X) > CInt(TextBox_AnalogDeadzone.Text) Then
+                            Tag.Value = MyController.RightThumbStick.X
                         Else
                             Tag.Value = 0
                         End If


### PR DESCRIPTION
Assigned wrong ThumbStick. 
Should be RightThumbStick.X but, LeftThumbStick.X is used.
In TwinCat, the X value of RightThumbStick changes when the left thumb stick is pushed and nothing happens when the right thumbstick is pushed along x axis. 